### PR TITLE
Duplicate barcodes

### DIFF
--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -19,6 +19,7 @@ BARCODE_FIELDS = [
 FIELDS = [
     "record_id",
     "redcap_event_name",
+    "back_end_scan_date",  # used for record disambiguation
     *BARCODE_FIELDS,
 ]
 
@@ -67,6 +68,7 @@ def main():
                     "label": f"{record.id} ({project.lang})",
                 },
                 "record_arm": record["redcap_event_name"],
+                "back_end_scan_date": record["back_end_scan_date"],
                 **{ field: normalize_barcode(record[field]) for field in BARCODE_FIELDS }
             }
 

--- a/datasette.yaml
+++ b/datasette.yaml
@@ -13,6 +13,7 @@ databases:
           select
             record_link as record,
             record_arm,
+            back_end_scan_date,
             pre_scan_barcode,
             utm_tube_barcode_2,
             reenter_barcode,

--- a/templates/pages/dial.html
+++ b/templates/pages/dial.html
@@ -92,6 +92,7 @@
       const params = new URLSearchParams({
         barcode: barcodeValue,
         _shape: "objects",
+        _hide_sql: 1,
       });
 
       const response = await fetch(`${formAction}.json?${params}`);
@@ -101,8 +102,10 @@
       if (resultCount === 0)
         throw exception("No result rows", result);
 
-      if (resultCount > 1)
-        throw exception("More than one result row", result);
+      if (resultCount > 1) {
+        window.open(`${formAction}?${params}`);
+        return;
+      }
 
       const recordLink = JSON.parse(result.rows[0].record).href;
 

--- a/templates/pages/dial.html
+++ b/templates/pages/dial.html
@@ -99,21 +99,21 @@
       const result = await response.json();
       const resultCount = result.rows.length;
 
-      if (resultCount === 0)
-        throw exception("No result rows", result);
+      if (resultCount === 1) {
+        const recordLink = JSON.parse(result.rows[0].record).href;
 
-      if (resultCount > 1) {
-        window.open(`${formAction}?${params}`);
-        return;
+        if (!recordLink)
+          throw exception("No link for record", result);
+
+        console.log(`Opening ${recordLink}`);
+        window.open(recordLink);
       }
-
-      const recordLink = JSON.parse(result.rows[0].record).href;
-
-      if (!recordLink)
-        throw exception("No link for record", result);
-
-      console.log(`Opening ${recordLink}`);
-      window.open(recordLink);
+      else if (resultCount > 1) {
+        window.open(`${formAction}?${params}`);
+      }
+      else {
+        throw exception("No result rows", result);
+      }
     }
 
     // XXX TODO: This could be more sophisticated, but for now it suffices to


### PR DESCRIPTION
When a barcode is dialed matching multiple records, redirect users to the canned `lookup-barcode` query. 
Add back end scan date to the exported data from REDCap, a field the lab requested that will be helpful for them in record disambiguation.  