### PR TITLE
Navigation to and from the dialer (/dial)

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,9 @@
+{% extends "default:index.html" %}
+
+{% block content %}
+<h1 style="padding-left: 10px; border-left: 10px solid blue">
+  SCAN Switchboard
+</h1>
+<h2><a href="dial">Dial a barcode</a></h2>
+<h2><a href="scan-redcap">Browse the data</a></h2>
+{% endblock %}

--- a/templates/pages/dial.html
+++ b/templates/pages/dial.html
@@ -4,8 +4,21 @@
   <meta charset="utf-8">
   <title>SCAN Switchboard</title>
   <style>
+    /* Copied from Datasette's default styles for body */
     body {
-      font-family: sans-serif;
+      margin: 0;
+      padding: 0;
+      font-family: "Helvetica Neue", sans-serif;
+      font-size: 1rem;
+      font-weight: 400;
+      line-height: 1.5;
+      color: #212529;
+      text-align: left;
+      background-color: #fff;
+    }
+
+    /* Styles for the dialer */
+    main {
       text-align: center;
     }
     #barcode, button {
@@ -21,9 +34,26 @@
     #error {
       color: red;
     }
+
+    /* Copied from Datasette's default styles for .hd */
+    nav {
+        border-bottom: 2px solid #ccc;
+        padding: 0.2em 1em;
+        background-color: #eee;
+        overflow: hidden;
+        box-sizing: border-box;
+        min-height: 2rem;
+    }
+    nav :link {
+        text-decoration: none;
+    }
   </style>
 </head>
 <body>
+<nav>
+  <a href="/">home</a>
+</nav>
+<main>
   <h1>SCAN Switchboard</h1>
 
   <p>Operators are standing by!</p>
@@ -163,5 +193,6 @@
 
     main().catch(console.error);
   </script>
+</main>
 </body>
 </html>


### PR DESCRIPTION
Provides a way to and from the dialer other than modifying the URL
directly.

Overrides the default Datasette home page to provide a short menu of
destinations.  Adds the Datasette nav bar styles to the dialer for
getting back to the home page.