### PR TITLE
Update SQLite database atomically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ SHELL := bash -euo pipefail
 .PHONY: data/scan-redcap.sqlite
 
 data/scan-redcap.sqlite: data/record-barcodes.ndjson derived-tables.sql
-	rm -vf $@
-	sqlite-utils insert --nl $@ record_barcodes $<
-	sqlite3 $@ < derived-tables.sql
+	sqlite-utils insert --nl $@.new record_barcodes $<
+	sqlite3 $@.new < derived-tables.sql
+	mv -vf $@.new $@
 
 data/record-barcodes.ndjson:
 	./bin/export-record-barcodes > $@


### PR DESCRIPTION
Otherwise Datasette hits transient errors because either the file doesn't exist (after the initial rm) or one of the tables doesn't yet exist.