### PR TITLE
Update records in SQLite via SQL instead of re-creating the database/file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,7 @@ SHELL := bash -euo pipefail
 .PHONY: data/scan-redcap.sqlite
 
 data/scan-redcap.sqlite: data/record-barcodes.ndjson derived-tables.sql
-	sqlite-utils insert --nl $@.new record_barcodes $<
-	sqlite3 $@.new < derived-tables.sql
-	mv -vf $@.new $@
+	./bin/update-database $< $@
 
 data/record-barcodes.ndjson:
 	./bin/export-record-barcodes > $@

--- a/bin/update-database
+++ b/bin/update-database
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+base="$(dirname "$0")/.."
+
+main() {
+    local records="$1"
+    local database="$2"
+    local table=record_barcodes
+
+    # XXX TODO: This whole block could be a new --truncate option to
+    # `sqlite-utils insert` once that's available.  That'd be nicer because
+    # it'd group the delete and insert into the same transaction, leaving no
+    # room for an empty table after a successful delete but failed insert.
+    #   -trs, 7 July 2020
+    if [[ -e "$database" ]]; then
+        # sqlite3 appears to exits non-zero on a SQL error only when the SQL
+        # statement is given as an argument; when reading from stdin it always
+        # seems to exit 0.
+        sqlite3 "$database" "delete from $table"
+    fi
+
+    sqlite-utils insert --nl "$database" "$table" "$records"
+    sqlite3 "$database" < "$base/derived-tables.sql"
+}
+
+main "$@"


### PR DESCRIPTION
This moves the update from the filesystem layer into the SQL layer, thus
allowing multiple processes to coordinate.  Datasette holds open SQLite
connections and was keeping references to the deleted files.

Since the Makefile recipe got more complicated, move it to a shell
script.

Resolves #10.