### PR TITLE
Reduce number of simultaneous connections to REDCap

### DIFF
--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -60,7 +60,7 @@ def main():
         ScanProject(23089, "en", "irb-kiosk"),
     ]
 
-    with ThreadPoolExecutor(15) as pool:
+    with ThreadPoolExecutor(8) as pool:
         for project_records in pool.map(lambda p: list(fetch_records(p)), projects):
             for record in project_records:
                 print(json.dumps(record, indent = None, separators = ",:"), flush = True)


### PR DESCRIPTION
We started seeing consistent TimeoutErrors thrown in production.  This
happened after a major REDCap upgrade, but it's not clear if it's
related on not.

The timeouts appear to be arising from the OS-level networking stack
since we don't set an explicit timeout for the "requests" library and
the exception isn't the Python-level socket library timeout class
socket.timeout.

On a hunch that REDCap can no longer service as many connections
simultaneously, reduce from 15 → 8.  Since we currently have 16
projects, each thread will take 2 projects.