### PR TITLE
Set ThreadPoolExector max threads to 1

### DIFF
--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -60,7 +60,7 @@ def main():
         ScanProject(23089, "en", "irb-kiosk"),
     ]
 
-    with ThreadPoolExecutor(8) as pool:
+    with ThreadPoolExecutor(1) as pool:
         for project_records in pool.map(lambda p: list(fetch_records(p)), projects):
             for record in project_records:
                 print(json.dumps(record, indent = None, separators = ",:"), flush = True)


### PR DESCRIPTION
We're still getting HTTP connect timeouts after we switched from 15 to 8 threads. This change sets the max threads to 1. A backoffice change will decrease the frequency with which this make gets invoked.