### PR TITLE
Insert records into 'new' table then rename tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ SHELL := bash -euo pipefail
 .PHONY: data/sfs-redcap.sqlite
 
 data/sfs-redcap.sqlite: data/record-barcodes.ndjson derived-tables.sql
-	sqlite-utils insert --nl --truncate $@ record_barcodes $<
+	sqlite-utils insert --nl --truncate $@ record_barcodes_new $<
+	sqlite3 $@ 'begin transaction; drop table if exists record_barcodes; alter table record_barcodes_new rename to record_barcodes; commit;'
 	sqlite3 $@ < derived-tables.sql
 
 data/record-barcodes.ndjson:


### PR DESCRIPTION
Switchboard users are complaining that sometimes when they search
for a valid barcode they get no results and then later they do. Looking
at how sqlite-utils populates the table, we see the potential for this
happening: the delete and the insert are not in the same transaction,
and with a growing number of records to insert, inserting all records is
taking longer. This means that there is a moment when the table is empty
and many moments before all the records are inserted into the table.

This commit causes sqlite-utils to insert the records into a temporary
table (not a temp table in the DB sense, but a table with 'new' appended
to its name). A sqlite3 command drops the existing table and renames
the new table to the real table name in a transaction.