### PR TITLE
Add timeout to SQL command

### DIFF
--- a/derived-tables.sql
+++ b/derived-tables.sql
@@ -1,3 +1,5 @@
+.timeout 10000
+
 drop table if exists duplicate_record_ids;
 
 create table duplicate_record_ids as


### PR DESCRIPTION
I'm sending this out as a PR so that you can see the change and how I reproduced the situation. I'm going to go ahead and merge and deploy it to see if this makes the error go away.


We are seeing instances where datasette is locking the sqlite database
and causing the `derived-tables.sql` task to fail with the error
`database is locked`.
This commit adds a 10 second timeout to the top of the SQL file.
This will let the command wait up to 10 seconds for the lock to
get removed so that it can run.

To reproduce the error run this batch:
for i in {1..100}
do
   sqlite3 data/sfs-redcap.sqlite < derived-tables.sql
done

And while that's running use datasette to access a barcode like:
http://127.0.0.1:3002/sfs-redcap/lookup-barcode?barcode=aaaaaaaa
Run that query a few times in a row and without the timeout you'll see
the `database is locked` error.