### PR TITLE
Add datasette timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,19 @@ The "barcode dialer" is at <http://localhost:8001/dial>.
 
 ## Troubleshooting
 
-On MacOS, if you see this error message:
+### On MacOS, if you see this error message:
 
     ./bin/serve: line 6: realpath: command not found
 
-You can install realpath as part of coreutils, using Homebrew:
+    You can install realpath as part of coreutils, using Homebrew:
 
     brew install coreutils
+
+### `database is locked` error
+    SQLite handles concurrency differently than a client-server database system does.
+    In SQLite, a write operation can lock the entire database and prevent readers
+    from accessing it, for example. This is good resource for learning about
+    locks in SQLite: https://sqlite.org/lockingv3.html
 
 
 [backoffice/id3c-production/env.d/redcap-scan/]: https://github.com/seattleflu/backoffice/tree/master/id3c-production/env.d/redcap-scan/

--- a/bin/serve
+++ b/bin/serve
@@ -11,5 +11,6 @@ exec datasette serve \
      --static static:"$base/static" \
      --template-dir "$base/templates" \
      --port "$PORT" \
+     --config sql_time_limit_ms:10000 \
      "$base/data/sfs-redcap.sqlite" \
      "$@"

--- a/templates/pages/dial.html
+++ b/templates/pages/dial.html
@@ -127,6 +127,11 @@
 
       const response = await fetch(`${formAction}.json?${params}`);
       const result = await response.json();
+
+      if (!result || !result.rows) {
+        throw exception("There was an error querying the database", result);
+      }
+
       const resultCount = result.rows.length;
 
       if (resultCount === 1) {


### PR DESCRIPTION
Switchboard users have reported getting a
`TypeError: Cannot read property 'length' of undefined`
error when trying to look up a barcode. This is an intermittent
error, and we tracked this back to to the sqlite database being
locked while records are loading.

This commit adds a timeout to datasette config to let a query
try for 10 seconds (instead of the default of 1 second). This should
accommodate periods when the query needs to wait for the database
to be available.

In here we also look for the specific error situation and show a
clearer exception message.