### PR TITLE
Use 5 threads for pulling REDCap records

### DIFF
--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -236,7 +236,7 @@ def main():
 
     ]
 
-    with ThreadPoolExecutor(1) as pool:
+    with ThreadPoolExecutor(5) as pool:
         for project_records in pool.map(lambda p: list(fetch_records(p)), projects):
             for record in project_records:
                 print(json.dumps(record, indent = None, separators = ",:"), flush = True)

--- a/datasette.yaml
+++ b/datasette.yaml
@@ -5,7 +5,7 @@ databases:
     title: SFS REDCap
     description_html: |
       <p>Summary information aggregated across the language-specific REDCap projects used by SFS.
-      <p><em>Updated every 5 minutes.</em>
+      <p><em>Updated every 30 minutes.</em>
     queries:
       lookup-barcode:
         title: Barcode lookup


### PR DESCRIPTION
Originally, 15 threads were used to pull records from REDCap
simulatenously. That proved too much, and we started seeing TimeOut
errors. We then tried 8 threads. That worked for a while, but we started
getting timeouts again, so we went all the way down to 1 thread. I just
ran many times locally with 5 threads and never got an error. This cuts
the REDCap record gathering time from 110 seconds (1 thread) to half,
55 seconds (5 threads). I went crazy and tried 25 threads. The gathering
took 46 seconds. Keeping the thread count low so that we don't hit
timeouts seems worth an extra 10 seconds.