### PR TITLE
Modify input barcode field restrictions

### DIFF
--- a/templates/pages/dial.html
+++ b/templates/pages/dial.html
@@ -64,7 +64,7 @@
       id="barcode"
       name="barcode"
       required
-      pattern="^[A-Fa-f0-9]{8}$"
+      pattern="^[A-Za-z0-9]{6,}$"
       placeholder="Dial a barcode…"
       autocomplete="off"
       autofocus>


### PR DESCRIPTION
Barcodes still should only be 8 characters made up of only 0–9 and A–F.
However, we fairly frequently get mistyped barcodes in REDCap due to
user error. We want to be able to use the Switchboard to quickly look
up incorrectly entered barcodes to pin them down in REDCap. Therefore,
loosen the input field restrictions in the Switchboard app so we can
look up "bad" barcodes, too.

Relax the restriction for number of characters from 8 to 6+ as
sometimes we receive truncated barcodes. Don't bother looking up
barcodes of 5 characters or fewer for now, because I assume the user
hasn't finished typing. (We can relax the number of characters
restriction again if we start receiving barcodes truncated to less than
6 characters in REDCap).

Also drop the restriction on the range of acceptable alphabet characters
for barcodes, because we often receive a character outside of the range
A–F when a barcode is mistyped.