### PR TITLE
Switch to new-style env vars for REDCap API credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,23 @@ _data/record-barcodes.ndjson_).
 You'll need to provide several environment variables with REDCap API
 credentials:
 
-    REDCAP_API_URL
-    REDCAP_API_TOKEN_EN
-    REDCAP_API_TOKEN_ES
-    REDCAP_API_TOKEN_VI
-    REDCAP_API_TOKEN_ZH_HANT
-    REDCAP_API_TOKEN_UW_REOPENING
-    REDCAP_API_TOKEN_CHILDCARE
-    …
+    REDCAP_API_TOKEN_redcap.iths.org_20759
+    REDCAP_API_TOKEN_redcap.iths.org_21520
+    REDCAP_API_TOKEN_redcap.iths.org_21521
+    REDCAP_API_TOKEN_redcap.iths.org_22461
+    REDCAP_API_TOKEN_redcap.iths.org_22467
+    REDCAP_API_TOKEN_redcap.iths.org_22468
+    REDCAP_API_TOKEN_redcap.iths.org_22470
+    REDCAP_API_TOKEN_redcap.iths.org_22471
+    REDCAP_API_TOKEN_redcap.iths.org_22472
+    REDCAP_API_TOKEN_redcap.iths.org_22473
+    REDCAP_API_TOKEN_redcap.iths.org_22474
+    REDCAP_API_TOKEN_redcap.iths.org_22475
+    REDCAP_API_TOKEN_redcap.iths.org_22476
+    REDCAP_API_TOKEN_redcap.iths.org_22477
+    REDCAP_API_TOKEN_redcap.iths.org_23089
 
-These are the same variables used in the [backoffice/id3c-production/env.d/redcap-scan/] and [backoffice/id3c-production/env.d/redcap-sfs] envdirs.
+These are the same variables used in the [backoffice/id3c-production/env.d/redcap/] envdir.
 
 
 # Serving the data

--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -24,12 +24,7 @@ log = logging.getLogger(__name__)
 log.setLevel(LOG_LEVEL)
 
 
-REDCAP_API_URL = environ["REDCAP_API_URL"]
-REDCAP_API_TOKEN_SCAN = lambda lang, purview: \
-    environ["REDCAP_API_TOKEN_%s" % lang.upper().replace("-", "_")] if purview == "ph" else \
-    environ["REDCAP_API_TOKEN_%s_%s" % (purview.upper().replace("-", "_"), lang.upper().replace("-", "_"))]
-REDCAP_API_TOKEN_UW_REOPENING = environ["REDCAP_API_TOKEN_UW_REOPENING"]
-REDCAP_API_TOKEN_CHILDCARE = environ["REDCAP_API_TOKEN_CHILDCARE"]
+REDCAP_API_URL = "https://redcap.iths.org/api/"
 
 BARCODE_FIELDS = [
     "pre_scan_barcode",
@@ -55,7 +50,7 @@ FIELDS = [
 
 class HuskyProject(redcap.Project):
     def __init__(self, project_id: str) -> None:
-        super().__init__(REDCAP_API_URL, REDCAP_API_TOKEN_UW_REOPENING, project_id)
+        super().__init__(REDCAP_API_URL, project_id)
         self.lang = 'en'
         self.purview = 'irb'
         # There are currently two events for this project: Enrollment and
@@ -82,7 +77,7 @@ class ScanProject(redcap.Project):
         Health), and a REDCap project *event_id_map* that contains a map of a
         project's unique event name to the associated `event_id` in REDCap.
         """
-        super().__init__(REDCAP_API_URL, REDCAP_API_TOKEN_SCAN(lang, purview), project_id)
+        super().__init__(REDCAP_API_URL, project_id)
         self.lang = lang
         self.purview = purview
         self.event_id_map = event_id_map
@@ -90,7 +85,7 @@ class ScanProject(redcap.Project):
 
 class ChildcareProject(redcap.Project):
     def __init__(self, project_id: str) -> None:
-        super().__init__(REDCAP_API_URL, REDCAP_API_TOKEN_CHILDCARE, project_id)
+        super().__init__(REDCAP_API_URL, project_id)
         self.lang = 'en'
         self.purview = 'irb'
         self.event_id_map = {


### PR DESCRIPTION
Makes for easier, unified handling across our codebases and so many
REDCap projects.