### PR TITLE
Include barcodes from AFH and Workplace Outbreaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ credentials:
     REDCAP_API_TOKEN_redcap.iths.org_22476
     REDCAP_API_TOKEN_redcap.iths.org_22477
     REDCAP_API_TOKEN_redcap.iths.org_23089
+    REDCAP_API_TOKEN_redcap.iths.org_27619
 
 These are the same variables used in the [backoffice/id3c-production/env.d/redcap/] envdir.
 

--- a/bin/export-record-barcodes
+++ b/bin/export-record-barcodes
@@ -36,6 +36,8 @@ BARCODE_FIELDS = [
     "barcode_swabsend",
     *[f'barcode_{i}' for i in range(1,17)],
     *[f'barcode_optional_{i}' for i in range(1,5)],
+    "core_collection_barcode",
+    "return_collection_barcode",
 ]
 
 FIELDS = [
@@ -110,6 +112,12 @@ class ChildcareProject(redcap.Project):
             'enrollment_arm_2': 742438,
             'week_2_arm_2': 742439,
         }
+
+class AFHWorkplaceOutbreakProject(redcap.Project):
+    def __init__(self, project_id: str) -> None:
+        super().__init__(REDCAP_API_URL, project_id)
+        self.lang = 'en'
+        self.purview='clinical'
 
 
 def main():
@@ -221,7 +229,10 @@ def main():
         HuskyProject(23854),
 
         # Childcare Study
-        ChildcareProject(23740)
+        ChildcareProject(23740),
+
+        # Adult Family Home and Workplace Outbreaks Study
+        AFHWorkplaceOutbreakProject(27619)
 
     ]
 
@@ -234,19 +245,21 @@ def main():
 def fetch_records(project):
     log.debug(f'Parsing project {project.id}')
 
-    event_arm = {
-        event["unique_event_name"]: event["arm_num"]
-            for event in project._fetch("event") }
+    if project._details["is_longitudinal"]:
+        event_arm = {
+            event["unique_event_name"]: event["arm_num"]
+                for event in project._fetch("event") }
 
     for record in project.records(fields=FIELDS, raw=True):
-        event_name = record["redcap_event_name"]
-        arm = event_arm[event_name]
-
         query_params = {
             "pid": project.id,
-            "arm": arm,
             "id": record.id,
         }
+
+        if project._details["is_longitudinal"]:
+            event_name = record["redcap_event_name"]
+            arm = event_arm[event_name]
+            query_params['arm'] = arm
 
         # Only deep link to the PCDEQC form if it exists
         # ([post_collection_data_entry_qc_complete] != ""). Otherwise, link to
@@ -255,7 +268,8 @@ def fetch_records(project):
             redcap_endpoint = 'record_home'
         else:
             query_params['page'] = 'post_collection_data_entry_qc'
-            query_params['event_id'] = project.event_id_map[event_name]
+            if project._details["is_longitudinal"]:
+                query_params['event_id'] = project.event_id_map[event_name]
             redcap_endpoint = 'index'
             # Instance is only needed for deep linking to a specific form, so
             # don't bother including it in the query if we're directing users
@@ -280,7 +294,6 @@ def fetch_records(project):
                 "href": record_url,
                 "label": f"{record.id} ({project.lang})",
             },
-            "event_name": event_name,
             "back_end_scan_date": record.get("back_end_scan_date"),
 
             # The barcode fields were made optional for the SCAN IRB Kiosk project
@@ -289,6 +302,9 @@ def fetch_records(project):
             # jccraft 07/17/2020
             **{ field: normalize_barcode(record.get(field)) for field in BARCODE_FIELDS }
         }
+
+        if project._details["is_longitudinal"]:
+            data['event_name'] = event_name
 
         yield data
 

--- a/datasette.yaml
+++ b/datasette.yaml
@@ -40,7 +40,9 @@ databases:
             barcode_optional_1,
             barcode_optional_2,
             barcode_optional_3,
-            barcode_optional_4
+            barcode_optional_4,
+            core_collection_barcode,
+            return_collection_barcode
           from
             record_barcodes
           where
@@ -71,7 +73,9 @@ databases:
               barcode_optional_1,
               barcode_optional_2,
               barcode_optional_3,
-              barcode_optional_4
+              barcode_optional_4,
+              core_collection_barcode,
+              return_collection_barcode
             )
           order by
             project_id,

--- a/derived-tables.sql
+++ b/derived-tables.sql
@@ -46,7 +46,9 @@ create table duplicate_record_ids as
         barcode_optional_1,
         barcode_optional_2,
         barcode_optional_3,
-        barcode_optional_4
+        barcode_optional_4,
+        core_collection_barcode,
+        return_collection_barcode
     from
         record_barcodes
     where


### PR DESCRIPTION
Include barcodes from Adult Family Homes and Workplace Outbreaks on the
switchboard. This project is a "classic" RedCAP project, such that it is not
longitudinal and does not have events or arms. The RedCAP API call to fetch
events will fail for classic projects, and we don't actually need to provide
and arm or event to construct the deep link URL into the PCDEQC instrument for
records in this classic project. Include barcode variables
(core_collection_barcode and return_collection_barcode) from the new project.

Constructed the RedCAP project using the new style, without explicitly passing
the token. This required updating the ID3C library, and I refreshed the
versions of other dependencies along with it.