### PR TITLE
Enable SQLite WAL mode in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHELL := bash -euo pipefail
 
 data/sfs-redcap.sqlite: data/record-barcodes.ndjson derived-tables.sql
 	sqlite3 $@ 'PRAGMA journal_mode=WAL;'
+	chmod -v g+w $@
 	sqlite-utils insert --nl --truncate $@ record_barcodes_new $<
 	sqlite3 $@ 'begin transaction; drop table if exists record_barcodes; alter table record_barcodes_new rename to record_barcodes; commit;'
 	sqlite3 $@ < derived-tables.sql

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SHELL := bash -euo pipefail
 .PHONY: data/sfs-redcap.sqlite venv requirements.txt
 
 data/sfs-redcap.sqlite: data/record-barcodes.ndjson derived-tables.sql
+	sqlite3 $@ 'PRAGMA journal_mode=WAL;'
 	sqlite-utils insert --nl --truncate $@ record_barcodes_new $<
 	sqlite3 $@ 'begin transaction; drop table if exists record_barcodes; alter table record_barcodes_new rename to record_barcodes; commit;'
 	sqlite3 $@ < derived-tables.sql


### PR DESCRIPTION
Explicitly set the SQLite database to the WAL mode. This handles
the scenario when we delete the database files and let the code create
new ones after we modify the columns in the underlying tables. Without
explicitly setting WAL mode, the database would stay in the 'delete'
(the default) mode.

Setting WAL mode when the database is already in WAL mode in a no-op.